### PR TITLE
Added classes to copy files, copy directories

### DIFF
--- a/notion-core/src/main/scala/com/ambiata/notion/core/InputOutputLocations.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/InputOutputLocations.scala
@@ -1,0 +1,106 @@
+package com.ambiata.notion.core
+
+import com.ambiata.saws.s3.S3Pattern
+import org.apache.hadoop.fs.Path
+import ExecutionLocation._
+
+/**
+ * Type for execution locations.
+ *
+ * An execution can only take place locally or on Hdfs
+ */
+sealed trait ExecutionLocation {
+  def fold[T](onHdfs: String => T, onLocal: String => T): T
+
+  /** extract a Path for local and hdfs execution in order to pass it to a map-reduce job */
+  def path: Path =
+    fold(path => new Path(path), path => new Path(path))
+
+  def render: String =
+    fold(identity, identity)
+}
+
+object ExecutionLocation {
+
+  def fromLocation(location: Location): Option[ExecutionLocation] =
+    location match {
+      case HdfsLocation(path)  => Some(HdfsExecutionLocation(path))
+      case LocalLocation(path) => Some(LocalExecutionLocation(path))
+      case S3Location(_, _)    => None
+    }
+
+  def HdfsExecutionLocation(p: String): ExecutionLocation =
+    new ExecutionLocation {
+      def fold[T](onHdfs: String => T, onLocal: String => T): T =
+        onHdfs(p)
+    }
+
+  def LocalExecutionLocation(p: String): ExecutionLocation =
+    new ExecutionLocation {
+      def fold[T](onHdfs: String => T, onLocal: String => T): T =
+        onLocal(p)
+    }
+}
+
+/**
+ * A Location for input / output files
+ *
+ * Some inputs/outputs need to be copied to a second location before being used. We have 5 cases:
+ *
+ *  - local input/output && local execution => no synchronisation required
+ *  - hdfs  input/output && hdfs execution  => no synchronisation required
+ *  - local input/output && hdfs execution  => synchronisation required
+ *  - s3    input/output && local execution => synchronisation required
+ *  - s3    input/output && hdfs execution  => synchronisation required
+ */
+sealed trait SynchronizedLocation {
+  def fold[T](
+               onLocalNoSync:   String => T,
+               onHdfsNoSync:    String => T,
+               onLocalHdfsSync: (String, String) => T,
+               onS3LocalSync:   (S3Pattern, String) => T,
+               onS3HdfsSync:    (S3Pattern, String) => T
+               ): T
+
+  def executionLocation: ExecutionLocation =
+    fold(path                                => LocalExecutionLocation(path),
+         path                                => HdfsExecutionLocation(path),
+         (local: String, hdfs: String)       => HdfsExecutionLocation(hdfs),
+         (pattern: S3Pattern, local: String) => LocalExecutionLocation(local),
+         (pattern: S3Pattern, hdfs: String)  => HdfsExecutionLocation(hdfs))
+
+  def path: Path = executionLocation.path
+
+}
+
+object SynchronizedLocation {
+  def LocalNoSync(local: String): SynchronizedLocation = new SynchronizedLocation {
+    def fold[T](onLocalNoSync: String => T, onHdfsNoSync: String => T, onLocalHdfsSync: (String, String) => T,
+                onS3LocalSync: (S3Pattern, String) => T, onS3HdfsSync: (S3Pattern, String) => T): T =
+      onLocalNoSync(local)
+  }
+
+  def HdfsNoSync(hdfs: String): SynchronizedLocation = new SynchronizedLocation {
+    def fold[T](onLocalNoSync: String => T, onHdfsNoSync: String => T, onLocalHdfsSync: (String, String) => T,
+                onS3LocalSync: (S3Pattern, String) => T, onS3HdfsSync: (S3Pattern, String) => T): T =
+      onHdfsNoSync(hdfs)
+  }
+
+  def LocalHdfsSync(local: String, hdfs: String): SynchronizedLocation = new SynchronizedLocation {
+    def fold[T](onLocalNoSync: String => T, onHdfsNoSync: String => T, onLocalHdfsSync: (String, String) => T,
+                onS3LocalSync: (S3Pattern, String) => T, onS3HdfsSync: (S3Pattern, String) => T): T =
+      onLocalHdfsSync(local, hdfs)
+  }
+
+  def S3LocalSync(pattern: S3Pattern, local: String): SynchronizedLocation = new SynchronizedLocation {
+    def fold[T](onLocalNoSync: String => T, onHdfsNoSync: String => T, onLocalHdfsSync: (String, String) => T,
+                onS3LocalSync: (S3Pattern, String) => T, onS3HdfsSync: (S3Pattern, String) => T): T =
+      onS3LocalSync(pattern, local)
+  }
+
+  def S3HdfsSync(pattern: S3Pattern, hdfs: String): SynchronizedLocation = new SynchronizedLocation {
+    def fold[T](onLocalNoSync: String => T, onHdfsNoSync: String => T, onLocalHdfsSync: (String, String) => T,
+                onS3LocalSync: (S3Pattern, String) => T, onS3HdfsSync: (S3Pattern, String) => T): T =
+      onS3HdfsSync(pattern, hdfs)
+  }
+}

--- a/notion-core/src/test/scala/com/ambiata/notion/core/Arbitraries.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/Arbitraries.scala
@@ -1,8 +1,9 @@
 package com.ambiata.notion.core
 
 import com.ambiata.notion.core.TemporaryType._
-import org.apache.hadoop.conf.Configuration
-import org.scalacheck._
+import com.ambiata.saws.s3.S3Pattern
+import org.scalacheck._, Arbitrary._
+import com.ambiata.saws.testing.Arbitraries._
 
 object Arbitraries {
   // This is a little dodgy, but means that property tests can be run on Travis without having AWS access
@@ -15,6 +16,30 @@ object Arbitraries {
     Arbitrary(if (awsEnabled) Gen.oneOf(Posix, S3, Hdfs) else Gen.oneOf(Posix, Hdfs))
   }
 
+  implicit def LocationArbitrary: Arbitrary[Location] = Arbitrary {
+    Gen.frequency((1, arbitrary[HdfsLocation]: Gen[Location]),
+      (1, arbitrary[LocalLocation]),
+      (1, arbitrary[S3Location]))
+  }
 
+  implicit def LocalLocationArbitrary: Arbitrary[LocalLocation] =
+    Arbitrary(genPath.map(p => LocalLocation("file:///"+p)))
+
+  implicit def HdfsLocationArbitrary: Arbitrary[HdfsLocation] =
+    Arbitrary(genPath.map(p => HdfsLocation("hdfs:///"+p)))
+
+  implicit def S3LocationArbitrary: Arbitrary[S3Location] =
+    Arbitrary(S3PatternArbitrary.arbitrary.map { case S3Pattern(b, k) => S3Location(b, k) })
+
+  case class Path(path: String) {
+    def onHdfs = "hdfs:///"+path
+    def onLocal = "file:///"+path
+  }
+
+  implicit def ArbitraryPath: Arbitrary[Path] =
+    Arbitrary(genPath.map(Path))
+
+  def genPath: Gen[String] =
+    Gen.nonEmptyListOf(Gen.identifier).map(_.mkString("/"))
 
 }

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopy.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopy.scala
@@ -1,0 +1,61 @@
+package com.ambiata.notion.distcopy
+
+import com.ambiata.mundane.control.RIO
+import com.ambiata.mundane.io._
+import com.ambiata.notion.core._
+import com.ambiata.poacher.hdfs.Hdfs
+import com.ambiata.saws.s3._
+import org.apache.hadoop.fs._
+
+import scalaz.Scalaz._
+
+/**
+ * Copy functions between Hdfs and S3
+ */
+object DistCopy {
+
+  /**
+   * Download a large directory by doing a distcopy from s3 to a hdfs directory
+   *
+   * Don't copy files which have already been copied
+   */
+  def downloadDirectory(from: S3Location, to: HdfsLocation, locationIO: LocationIO): RIO[Unit] =
+    for {
+      fromAddresses <- S3Prefix(from.bucket, from.key).listAddress.execute(locationIO.s3Client)
+      mappings      <- fromAddresses.traverseU(createDownloadMapping(to, locationIO))
+      _             <- DistCopyJob.run(Mappings(mappings.toVector.flatten), distCopyConfiguration(locationIO))
+    } yield ()
+
+  /** upload a large file by doing a distcopy from hdfs to s3 */
+  def uploadDirectory(from: HdfsLocation, to: S3Location, locationIO: LocationIO): RIO[Unit] =
+    for {
+      fromPaths <- Hdfs.globFiles(new Path(from.path, "*")).run(locationIO.configuration)
+      mappings  <- fromPaths.traverseU(createUploadMapping(to, locationIO))
+      _         <- DistCopyJob.run(Mappings(mappings.toVector.flatten), distCopyConfiguration(locationIO))
+    } yield ()
+
+  /** @return true if the path exists */
+  def pathExist(path: Path, locationIO: LocationIO): RIO[Boolean] =
+    Hdfs.exists(path).run(locationIO.configuration)
+
+  /** @return true if the address exists */
+  def addressExist(address: S3Address, locationIO: LocationIO): RIO[Boolean] =
+    address.exists.execute(locationIO.s3Client)
+
+  /** @return a configuration for dist copy based on the current LocationIO configuration */
+  def distCopyConfiguration(locationIO: LocationIO): DistCopyConfiguration =
+    DistCopyConfiguration.Default.copy(hdfs = locationIO.configuration, client = locationIO.s3Client)
+
+  /** create a Download mapping for a file if it doesn't exist */
+  def createDownloadMapping(to: HdfsLocation, locationIO: LocationIO)(address: S3Address): RIO[Option[DownloadMapping]] = {
+    val toPath = new Path((to.dirPath <|> FilePath.unsafe(address.key).basename).path)
+    pathExist(toPath, locationIO).map(exists => if (exists) None else Some(DownloadMapping(address, toPath)))
+  }
+
+  /** create an Upload mapping for a file if it doesn't exist */
+  def createUploadMapping(to: S3Location, locationIO: LocationIO)(path: Path): RIO[Option[UploadMapping]] = {
+    val toAddress = S3Prefix(to.bucket, to.key) | path.getName
+    addressExist(toAddress, locationIO).map(exists => if (exists) None else Some(UploadMapping(path, toAddress)))
+  }
+}
+

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/SynchronizedInputsOutputs.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/SynchronizedInputsOutputs.scala
@@ -1,0 +1,159 @@
+package com.ambiata.notion
+package distcopy
+
+import DistCopy._
+import com.ambiata.mundane.control._
+import com.ambiata.mundane.io._
+import com.ambiata.notion.core._
+import com.ambiata.saws.s3.S3Pattern
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs._
+import scalaz._, Scalaz._
+import SynchronizedLocation._
+
+/**
+ * Those functions can be used to prepare input and output files for MapReduce applications
+ * by downloading input files to the cluster and uploading results to S3
+ *
+ * The usage is:
+ *
+ *  1. validateShadowDir to make sure it is valid to use a shadow directory given the location of input/output files + the configuration
+ *  2. createSynchronizedLocations for input files
+ *  3. synchronizeInputs
+ *  4. run the application using the synchronized input paths or locations
+ */
+object SynchronizedInputsOutputs {
+
+  /**
+   * Validate the shadow directory location
+   *
+   *  - the shadow dir must be in a location that is compatible with the configuration in LocationIO
+   *  - if the shadow dir is not defined then
+   *     - if the configuration is local, then all input/output locations must be local
+   *     - if the configuration is hdfs then all input/output locations must be hdfs
+   *  - if the shadow dir is defined on hdfs
+   *     - the configuration must be on hdfs
+   *     - at least one input or output location is not hdfs
+   *  - if the shadow dir is defined on local
+   *     - the configuration must be local
+   *     - at least one input or output location is not local and no location is hdfs
+   *  - the shadow dir can not be defined on S3
+   */
+  def validateShadowDir(shadowDir: Option[Location], locations: List[Location], locationIO: LocationIO): String \/ Option[ExecutionLocation] = {
+    val locationsRendered = locations.mkString("\n", "\n", "\n")
+
+    shadowDir match {
+      case None =>
+        if (isClusterConfiguration(locationIO.configuration))
+          if (locations.forall(isHdfsLocation)) None.right
+          else s"the shadow directory must be defined when the configuration is using the cluster and some input/output locations are not hdfs. Got $locationsRendered".left
+        else
+        if (locations.forall(isLocalLocation)) None.right
+        else s"the shadow directory must be defined when the configuration is local and some input/output locations are not local. Got $locationsRendered".left
+
+      case Some(h @ HdfsLocation(_)) =>
+        if (isClusterConfiguration(locationIO.configuration))
+          if (locations.forall(isHdfsLocation)) s"all input/output locations are defined on hdfs. In that case no shadow directory should be defined. Got ${h.render}".left
+          else ExecutionLocation.fromLocation(h).right
+        else
+          s"the shadow directory can not be defined on the cluster when the configuration is local. Got ${h.render}".left
+
+      case Some(l @ LocalLocation(_)) =>
+        if (isClusterConfiguration(locationIO.configuration))
+          s"the shadow directory can not be defined locally when the configuration is on hdfs. Got ${l.render}".left
+        else
+        if (locations.forall(isLocalLocation)) s"all input/output locations are defined locally. In that case no shadow directory should be defined. Got ${l.render}".left
+        else ExecutionLocation.fromLocation(l).right
+
+      case Some(s @ S3Location(_, _)) =>
+        s"the shadow directory can not be defined on S3. Got ${s.render}".left
+    }
+  }
+
+  /**
+   * Create a synchronized location based on the location of the shadow directory if there is one
+   */
+  def createSynchronizedLocation(shadowDir: Option[ExecutionLocation], location: Location): String \/ SynchronizedLocation = {
+    (shadowDir, location) match {
+      // cluster execution
+      case (Some(sd), l @ LocalLocation(p)) =>
+        sd.fold(path => LocalHdfsSync(p, (DirPath.unsafe(path) </> DirPath.unsafe(p)).path),
+                path => LocalNoSync(p)).right
+
+      case (Some(sd), HdfsLocation(_)) =>
+        sd.fold(path => HdfsNoSync(path).right,
+                path => s"A synchronized location can not be on Hdfs when the execution is local. Got $path".left)
+
+      case (Some(sd), S3Location(b, k)) =>
+        sd.fold(path => S3HdfsSync(S3Pattern(b, k),  (DirPath.unsafe(path) </> DirPath.unsafe(k)).path),
+                path => S3LocalSync(S3Pattern(b, k), (DirPath.unsafe(path) </> DirPath.unsafe(k)).path)).right
+
+      // not defined: execution is either all local or all Hdfs
+      case (None, LocalLocation(p))     => LocalNoSync(p).right
+      case (None, HdfsLocation(p) )     => HdfsNoSync(p).right
+      case (None, s @ S3Location(_, _)) => s"A synchronized location can not be on S3 when no shadow directory is defined. Got ${s.render}".left
+    }
+  }
+
+  /**
+   * Download input files or directories, using distcopy to synchronize files or directories when
+   * going from S3 to Hdfs
+   */
+  def synchronizeInputs(inputs: List[SynchronizedLocation], overwrite: Boolean, locationIO: LocationIO): RIO[Unit] = {
+    inputs.traverseU(_.fold(
+      hdfs  => RIO.ok(()),
+      local => RIO.ok(()),
+      (local, hdfs)    => locationIO.copyFiles(LocalLocation(local), HdfsLocation(hdfs), overwrite),
+      (pattern, local) => locationIO.copyFiles(S3Location(pattern.bucket, pattern.unknown), LocalLocation(local), overwrite),
+      (pattern, hdfs)  => copyFromS3ToHdfs(S3Location(pattern.bucket, pattern.unknown), HdfsLocation(hdfs), overwrite, locationIO)
+    )).void
+  }
+
+  /**
+   * Upload output files or directories, using distcopy to synchronize files or directories when
+   * going from Hdfs to S3
+   */
+  def synchronizeOutputs(outputLocations: List[SynchronizedLocation], overwrite: Boolean, locationIO: LocationIO): RIO[Unit] =
+    outputLocations.traverseU(_.fold(
+      hdfs  => RIO.ok(()),
+      local => RIO.ok(()),
+      (local, hdfs)    => locationIO.copyFiles(LocalLocation(local), HdfsLocation(hdfs), overwrite),
+      (pattern, local) => locationIO.copyFiles(LocalLocation(local), S3Location(pattern.bucket, pattern.unknown), overwrite),
+      (pattern, hdfs)  => copyFromHdfsToS3(HdfsLocation(hdfs), S3Location(pattern.bucket, pattern.unknown), overwrite, locationIO)
+    )).void
+
+  /** @return true if this configuration is for a cluster job (not local) */
+  def isClusterConfiguration(configuration: Configuration): Boolean =
+    FileSystem.getDefaultUri(configuration).getScheme == "hdfs"
+
+  /** @return true if this configuration is for a local job */
+  def isLocalConfiguration(configuration: Configuration) =
+    !isClusterConfiguration(configuration)
+
+  def isHdfsLocation(location: Location): Boolean =
+    location match {
+      case HdfsLocation(_)  => true
+      case LocalLocation(_) => false
+      case S3Location(_,_)  => false
+    }
+
+  def isLocalLocation(location: Location): Boolean =
+    location match {
+      case HdfsLocation(_)  => false
+      case LocalLocation(_) => true
+      case S3Location(_,_)  => false
+    }
+
+  def copyFromS3ToHdfs(source: S3Location, target: HdfsLocation, overwrite: Boolean, locationIO: LocationIO): RIO[Unit] =
+    locationIO.isDirectory(source) >>= { isDirectory =>
+      if (!isDirectory) locationIO.copyFile(source, target, overwrite)
+      else downloadDirectory(source, target, locationIO)
+    }
+
+  def copyFromHdfsToS3(source: HdfsLocation, target: S3Location, overwrite: Boolean, locationIO: LocationIO): RIO[Unit] =
+    locationIO.isDirectory(source) >>= { isDirectory =>
+      if (!isDirectory) locationIO.copyFile(source, target, overwrite)
+      else uploadDirectory(source, target, locationIO)
+    }
+}
+

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopySpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopySpec.scala
@@ -1,0 +1,74 @@
+package com.ambiata.notion
+package distcopy
+
+import com.ambiata.mundane.io._
+import com.ambiata.notion.core._
+import com.ambiata.poacher.hdfs._
+import com.ambiata.saws.core._
+import com.ambiata.saws.s3._
+import com.ambiata.saws.testing.Arbitraries._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.scalacheck._
+import com.ambiata.mundane.testing.RIOMatcher._
+import com.ambiata.saws.testing._
+
+class DistCopySpec extends AwsScalaCheckSpec(tests = 5) { def is = s2"""
+
+  A download mapping must not be created if the file already exists
+    if no file exists $downloadMappingIsSome
+    if a file exists  $downloadMappingIsNone
+
+  An upload mapping must not be created if the file already exists
+    if no file exists $uploadMappingIsSome
+    if a file exists  $uploadMappingIsNone
+
+"""
+
+  def downloadMappingIsSome = prop { (s3Temp: S3Temporary, hdfsTemp: HdfsTemporary) =>
+    for {
+      path    <- hdfsTemp.path.run(configuration)
+      address <- s3Temp.address.execute(s3Client)
+      result  <- DistCopy.createDownloadMapping(HdfsLocation(path.toString), locationIO)(address)
+    } yield result must beSome
+  }
+
+  def downloadMappingIsNone = prop { (s3Temp: S3Temporary, hdfsTemp: HdfsTemporary) =>
+    for {
+      path    <- hdfsTemp.path.run(configuration)
+      address <- s3Temp.address.execute(s3Client)
+      _       <- Hdfs.write(new Path(path, FilePath.unsafe(address.key).basename.name), "old lines").run(configuration)
+      result  <- DistCopy.createDownloadMapping(HdfsLocation(path.toString), locationIO)(address)
+    } yield result must beNone
+  }
+
+  def uploadMappingIsSome = prop { (s3Temp: S3Temporary, hdfsTemp: HdfsTemporary) =>
+    for {
+      path    <- hdfsTemp.path.run(configuration)
+      address <- s3Temp.pattern.execute(s3Client)
+      result  <- DistCopy.createUploadMapping(S3Location(address.bucket, address.unknown), locationIO)(path)
+    } yield result must beSome
+  }
+
+  def uploadMappingIsNone = prop { (s3Temp: S3Temporary, hdfsTemp: HdfsTemporary) =>
+    for {
+      path    <- hdfsTemp.path.run(configuration)
+      prefix  <- s3Temp.prefix.execute(s3Client)
+      address =  prefix | FilePath.unsafe(path.toString).basename.name
+      _       <- address.put("old lines").execute(s3Client)
+      result  <- DistCopy.createUploadMapping(S3Location(prefix.bucket, prefix.prefix), locationIO)(path)
+    } yield result must beNone
+  }
+
+  def locationIO = LocationIO(new Configuration, Clients.s3)
+  def configuration = locationIO.configuration
+  val s3Client = locationIO.s3Client
+
+  implicit def HdfsTemporaryArbitrary: Arbitrary[HdfsTemporary] = Arbitrary(for {
+    i <- Gen.choose(1, 5)
+    a <- Gen.listOfN(i, Gen.identifier)
+    z = a.mkString("/")
+    f <- Gen.oneOf("", "/")
+  } yield HdfsTemporary(s"temporary-${java.util.UUID.randomUUID().toString}/" + z + f))
+}
+

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/SynchronizedInputsOutputsSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/SynchronizedInputsOutputsSpec.scala
@@ -1,0 +1,144 @@
+package com.ambiata.notion
+package distcopy
+
+import com.ambiata.disorder.List10
+import com.ambiata.notion.core._
+import com.ambiata.saws.core.Clients
+import com.ambiata.saws.testing.AwsScalaCheckSpec
+import org.apache.hadoop.conf.Configuration
+import SynchronizedInputsOutputs._
+import org.scalacheck.{Gen, Arbitrary}
+import org.specs2.matcher._
+import Arbitrary._
+import com.ambiata.notion.core.Arbitraries._
+
+class SynchronizedInputsOutputsSpec extends AwsScalaCheckSpec(tests = 5) with DisjunctionMatchers { def is = s2"""
+
+ A configuration is a Cluster configuration if the file system scheme is hdfs $clusterConfiguration
+
+ When a shadow directory is used
+  the shadow dir must be in a location that is compatible with the configuration in LocationIO $validConfiguration
+
+  if the shadow dir is not defined then
+    if the configuration is local, then all input/output locations must be local
+    if the configuration is hdfs then all input/output locations must be hdfs                  $shadowDirNotDefined
+
+  if the shadow dir is defined on hdfs
+    the configuration must be on hdfs
+    at least one input or output location is not hdfs                                          $shadowDirOnHdfs
+
+  if the shadow dir is defined on local
+    the configuration must be local
+    at least one input or output location is not local and no location is hdfs                 $shadowDirOnLocal
+
+  the shadow dir can not be defined on S3                                                      $shadowDirOnS3
+
+ The synchronized location for a location on S3 depends on the shadow directory location.
+   The authorised combinations for the input location and the execution location are
+     Local / Local => LocalNoSync
+     Hdfs  / Hdfs  => HdfsNoSync
+     Local / Hdfs  => LocalHdfsSync
+     S3    / Hdfs  => S3HdfsSync
+     S3    / Local => S3LocalSync                                                              $createSyncLocation
+
+"""
+
+  def clusterConfiguration = prop { scheme: Scheme =>
+    isClusterConfiguration(createConfiguration(scheme)).iff(scheme.s == "hdfs")
+  }
+
+  def validConfiguration = prop { (shadowDirLocation: Location, s3: S3Location, local: LocalLocation, configuration: Configuration) =>
+    val valid1 =
+      isClusterConfiguration(configuration) && isHdfsLocation(shadowDirLocation) ||
+      isLocalConfiguration(configuration)   && isLocalLocation(shadowDirLocation)
+
+    // create a list of inputs which require a shadow directory
+    val inputs =
+      if (isClusterConfiguration(configuration)) List(local)
+      else List(s3)
+
+    val valid2 = validateShadowDir(Some(shadowDirLocation), inputs, new LocationIO(configuration, Clients.s3)).isRight
+
+    valid1 ==== valid2
+  }
+
+  def shadowDirNotDefined = prop { (locations: List10[Location], configuration: Configuration) =>
+    val valid1 =
+        isClusterConfiguration(configuration) && !locations.value.exists(l => !isHdfsLocation(l)) ||
+        isLocalConfiguration(configuration)   && !locations.value.exists(l => !isLocalLocation(l))
+
+    val valid2 = validateShadowDir(None, locations.value, new LocationIO(configuration, Clients.s3)).isRight
+
+    valid1 ==== valid2
+  }
+
+  def shadowDirOnHdfs = prop { (shadowDir: HdfsLocation, locations: List10[Location], configuration: Configuration) =>
+    val valid1 =
+      isClusterConfiguration(configuration) && locations.value.exists(l => !isHdfsLocation(l))
+
+    val valid2 = validateShadowDir(Some(shadowDir), locations.value, new LocationIO(configuration, Clients.s3)).isRight
+
+    valid1 ==== valid2
+  }
+
+  def shadowDirOnLocal = prop { (shadowDir: LocalLocation, locations: List10[Location], configuration: Configuration) =>
+    val valid1 =
+      isLocalConfiguration(configuration) && locations.value.exists(l => !isLocalLocation(l))
+
+    val valid2 = validateShadowDir(Some(shadowDir), locations.value, new LocationIO(configuration, Clients.s3)).isRight
+
+    valid1 ==== valid2
+  }
+
+  def shadowDirOnS3 = prop { (shadowDir: S3Location, locations: List10[Location], configuration: Configuration) =>
+    validateShadowDir(Some(shadowDir), locations.value, new LocationIO(configuration, Clients.s3)) must be_-\/
+  }
+
+  def createSyncLocation = prop { (location: Location, shadowDirLocation: Option[ExecutionLocation]) =>
+    val valid1 =
+      !shadowDirLocation.isDefined && !isS3Location(location) ||
+      shadowDirLocation.isDefined  && shadowDirLocation.exists(isHdfs) ||
+      shadowDirLocation.isDefined  && shadowDirLocation.exists(isLocal) && !isHdfsLocation(location)
+
+    val valid2 = createSynchronizedLocation(shadowDirLocation, location).isRight
+
+    valid1 ==> valid2 :| "v1 ==> v2" &&
+    valid2 ==> valid1 :| "v2 ==> v1"
+  }
+
+  /**
+   * HELPERS
+   */
+
+  implicit def ArbitraryExecutionLocation: Arbitrary[ExecutionLocation] =
+    Arbitrary(arbitrary[Location].map(ExecutionLocation.fromLocation).filter(_.isDefined).map(_.get))
+
+  def createConfiguration: Scheme => Configuration =  { scheme: Scheme =>
+    val c = new Configuration()
+    c.set("fs.defaultFS", scheme.s+":///")
+    c
+  }
+
+  case class Scheme(s: String)
+
+  implicit def ArbitraryConfiguration: Arbitrary[Configuration] =
+    Arbitrary(arbitrary[Scheme].map(createConfiguration))
+
+  implicit def ArbitraryScheme: Arbitrary[Scheme] =
+    Arbitrary(Gen.oneOf("hdfs", "file").map(Scheme))
+
+  def isHdfs(location: ExecutionLocation): Boolean =
+    location.fold(_ => true, _ => false)
+
+  def isLocal(location: ExecutionLocation): Boolean =
+    location.fold(_ => false, _ => true)
+
+  def isS3Location(location: Location): Boolean =
+    location match {
+      case S3Location(_,_)  => true
+      case HdfsLocation(_)  => false
+      case LocalLocation(_) => false
+    }
+
+  val locationIO = new LocationIO(new Configuration, Clients.s3)
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -67,7 +67,7 @@ object build extends Build {
       depend.hadoop(version.value) ++
       depend.disorder)
   )
-  .dependsOn(core)
+  .dependsOn(core, core % "test->test")
 
   lazy val compilationSettings: Seq[Settings] = Seq(
     javaOptions ++= Seq(

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -30,9 +30,9 @@ object depend {
 
   def poacher(version: String) =
     if (version.contains("cdh4"))
-      Seq("com.ambiata" %% "poacher" % "1.0.0-cdh4-20150310042320-6cc4adc" % "compile->compile;test->test") ++ hadoop(version)
+      Seq("com.ambiata" %% "poacher" % "1.0.0-cdh4-20150330223220-70a5956" % "compile->compile;test->test") ++ hadoop(version)
     else if (version.contains("cdh5"))
-      Seq("com.ambiata" %% "poacher" % "1.0.0-cdh5-20150310042301-6cc4adc" % "compile->compile;test->test") ++ hadoop(version)
+      Seq("com.ambiata" %% "poacher" % "1.0.0-cdh5-20150330223220-70a5956" % "compile->compile;test->test") ++ hadoop(version)
     else
       sys.error(s"unsupported poacher version, can not build for $version")
 


### PR DESCRIPTION
This PR provides a set of classes and methods to synchronize files using MR or local applications:

 - `ExecutionLocation` models where the execution takes place: `local` or `hdfs`
 - `SynchronizedLocation` models the different requirements for synchronization:
    - local file / local execution
    - hdfs file / hdfs execution
    - local file / hdfs execution
    - s3 file  / hdfs execution
    - s3 file  / local execution
 - methods to synchronize input or output files are provided (possibly using distcopy when synchronizing full directories)
 