### PR TITLE
Compute a file sha1 based on the streaming of bytes

### DIFF
--- a/notion-core/src/main/scala/com/ambiata/notion/core/BytesReducer.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/BytesReducer.scala
@@ -1,0 +1,30 @@
+package com.ambiata.notion
+package core
+
+import java.security.MessageDigest
+
+import com.ambiata.mundane.io._
+import Reducer._
+import com.ambiata.mundane.bytes.Buffer
+
+/**
+ * Part reducer for byte arrays
+ */
+object BytesReducer {
+
+  /** bytes reducer computing a SHA1 */
+  def sha1: BytesReducer[String] = new BytesReducer[String] {
+    type S = MessageDigest
+
+    val init: MessageDigest =
+      MessageDigest.getInstance("SHA-1")
+
+    def reduce(buffer: Buffer, md: MessageDigest): MessageDigest = {
+      md.update(buffer.bytes, buffer.offset, buffer.length)
+      md
+    }
+
+    def finalise(md: MessageDigest): String =
+      Checksum.toHexString(md.digest)
+  }
+}

--- a/notion-core/src/main/scala/com/ambiata/notion/core/LineReducer.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/LineReducer.scala
@@ -1,83 +1,20 @@
 package com.ambiata.notion
 package core
 
-import java.security.MessageDigest
-
-import com.ambiata.mundane.io.Checksum
-import org.apache.commons.codec.binary.Base64
-
 import scala.collection.mutable.Queue
-import scalaz.{Foldable, Monoid}
+import Reducer._
 
 /**
  * "Reducer-like" class to accumulate values while
  * reading a file and transforming them to a final value
  * when the whole file has been read
  */
-trait LineReducer[T] {
-  type S
-  
-  /** initial value */
-  def init: S
-
-  /** reducer function using the current line and the current state S */
-  def reduce(line: String, s: S): S
-
-  /** final value from the last state */
-  def finalise(s: S): T
-}
 
 object LineReducer {
 
-  /** zip two line reducers together - aka parallel composition */
-  implicit class ZippedLineReducer[T1](r1: LineReducer[T1]) {
-    def zip[T2](r2: LineReducer[T2]): LineReducer[(T1, T2)] = new LineReducer[(T1, T2)] {
-      type S = (r1.S, r2.S)
-
-      def init: S =
-        (r1.init, r2.init)
-
-      def reduce(line: String, s: S): S =
-        (r1.reduce(line, s._1), r2.reduce(line, s._2))
-
-      def finalise(s: S): (T1, T2) =
-        (r1.finalise(s._1), r2.finalise(s._2))
-    }
-  }
-
-  /** create a reducer from a Monoid and a function transforming each line to a value T */
-  def fromMonoid[M : Monoid](f: String => M) = new LineReducer[M] {
-    type S = M
-    
-    def init: S =
-      Monoid[S].zero
-
-    def reduce(line: String, s: S): S =
-      Monoid[S].append(f(line), s)
-
-    def finalise(s: S): S =
-      s
-  }
-
   /** line reducer counting lines */
   def linesNumber: LineReducer[Int] =
-    LineReducer.fromMonoid[Int](_ => 1)(scalaz.std.anyVal.intInstance)
-
-  /** line reducer computing a SHA1 */
-  def sha1: LineReducer[String] = new LineReducer[String] {
-    type S = MessageDigest
-
-    val init: MessageDigest =
-      MessageDigest.getInstance("SHA-1")
-
-    def reduce(line: String, md: MessageDigest): MessageDigest = {
-      md.update((line+"\n").getBytes("UTF-8"))
-      md
-    }
-
-    def finalise(md: MessageDigest): String =
-      Checksum.toHexString(md.digest)
-  }
+    Reducer.fromMonoid[String, Int](_ => 1)(scalaz.std.anyVal.intInstance)
 
   /** line reducer keeping the last N read lines */
   def tail(numberOfLines: Int): LineReducer[List[String]] = new LineReducer[List[String]] {
@@ -95,11 +32,6 @@ object LineReducer {
     def finalise(lines: Queue[String]): List[String] =
       lines.toList
   }
-
-  /** fold from the left a Foldable container of lines */
-  def foldLeft[F[_] : Foldable, T](lines: F[String], reducer: LineReducer[T]): T =
-    reducer.finalise(Foldable[F].foldLeft(lines, reducer.init)((s: reducer.S, line: String) => reducer.reduce(line, s)))
-
 }
 
 

--- a/notion-core/src/main/scala/com/ambiata/notion/core/LocationIO.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/LocationIO.scala
@@ -1,18 +1,17 @@
 package com.ambiata.notion.core
 
-import java.io.File
-import java.security.MessageDigest
 import com.ambiata.saws.core.{S3Action, Clients}
 import com.ambiata.com.amazonaws.services.s3.AmazonS3Client
 import com.ambiata.mundane.control._
 import com.ambiata.mundane.data.Lists
 import com.ambiata.mundane.io._
+import com.ambiata.mundane.bytes.Buffer
 import com.ambiata.poacher.hdfs.Hdfs
 import com.ambiata.saws.s3.{S3Prefix, S3Address, S3Pattern}
-import org.apache.commons.codec.binary.Base64
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import collection.mutable.Queue
+import java.io.File
+import Reducer._
 import scalaz._, Scalaz._, effect.IO, effect.Effect._
 
 /**
@@ -110,6 +109,19 @@ case class LocationIO(configuration: Configuration, s3Client: AmazonS3Client) {
       }}.as(state)
     }
 
+  /** read a file as a stream of bytes and compute some state value */
+  def streamBytes[A](location: Location, empty: => A, bufferSize: Int = 4096)(f: (Buffer, A) => A): RIO[A] =
+    RIO.io(empty).flatMap { s =>
+      var state = s
+      readUnsafe(location) { in => RIO.io {
+        val buffer = Buffer.wrapArray(Array.ofDim[Byte](bufferSize), 0, bufferSize)
+        var length = 0
+        while ({ length = in.read(buffer.bytes, buffer.offset, bufferSize); length != -1 }) {
+          state = f(Buffer.allocate(buffer, length), state)
+        }
+      }}.as(state)
+    }
+
   def writeUtf8Lines(location: Location, lines: List[String]): RIO[Unit] =
     writeUtf8(location, Lists.prepareForFile(lines))
 
@@ -169,6 +181,9 @@ case class LocationIO(configuration: Configuration, s3Client: AmazonS3Client) {
   def reduceLinesUTF8[T](location: Location, reducer: LineReducer[T]): RIO[T] =
     streamLinesUTF8[reducer.S](location, reducer.init)((line, s) => reducer.reduce(line, s)).map(s => reducer.finalise(s))
 
+  def reduceBytes[T](location: Location, reducer: BytesReducer[T]): RIO[T] =
+    streamBytes[reducer.S](location, reducer.init)((bytes, s) => reducer.reduce(bytes, s)).map(s => reducer.finalise(s))
+
   /** get the last line of a file */
   def tail(location: Location, numberOfLines: Int): RIO[List[String]] =
     reduceLinesUTF8(location, LineReducer.tail(numberOfLines))
@@ -176,5 +191,4 @@ case class LocationIO(configuration: Configuration, s3Client: AmazonS3Client) {
   /** get the last line of a file */
   def lastLine(location: Location): RIO[Option[String]] =
     tail(location, numberOfLines = 1).map(_.lastOption)
-
 }

--- a/notion-core/src/main/scala/com/ambiata/notion/core/LocationIO.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/LocationIO.scala
@@ -114,10 +114,11 @@ case class LocationIO(configuration: Configuration, s3Client: AmazonS3Client) {
     RIO.io(empty).flatMap { s =>
       var state = s
       readUnsafe(location) { in => RIO.io {
-        val buffer = Buffer.wrapArray(Array.ofDim[Byte](bufferSize), 0, bufferSize)
+        var buffer = Buffer.wrapArray(Array.ofDim[Byte](bufferSize), 0, bufferSize)
         var length = 0
         while ({ length = in.read(buffer.bytes, buffer.offset, bufferSize); length != -1 }) {
-          state = f(Buffer.allocate(buffer, length), state)
+          buffer = Buffer.allocate(buffer, length)
+          state = f(buffer, state)
         }
       }}.as(state)
     }

--- a/notion-core/src/main/scala/com/ambiata/notion/core/Reducer.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/Reducer.scala
@@ -1,0 +1,62 @@
+package com.ambiata.notion.core
+
+import scalaz.{Foldable, Monoid}
+import com.ambiata.mundane.bytes.Buffer
+
+/**
+ * "Reducer-like" class to accumulate values while
+ * reading "parts" (bytes, lines) from a file and transforming them to a final value
+ * when the whole file has been read
+ */
+trait Reducer[P, T] { outer =>
+  type S
+  
+  /** initial value */
+  def init: S
+
+  /** reducer function using the current part and the current state S */
+  def reduce(part: P, s: S): S
+
+  /** final value from the last state */
+  def finalise(s: S): T
+
+  /** zip 2 reducers together to produce a Reducer[P, (T, T2)] */
+  def zip[T2](r2: Reducer[P, T2]): Reducer[P, (T, T2)] = new Reducer[P, (T, T2)] {
+    type S = (outer.S, r2.S)
+
+    def init: S =
+      (outer.init, r2.init)
+
+    def reduce(p: P, s: S): S =
+      (outer.reduce(p, s._1), r2.reduce(p, s._2))
+
+    def finalise(s: S): (T, T2) =
+      (outer.finalise(s._1), r2.finalise(s._2))
+  }
+}
+
+object Reducer {
+
+  type LineReducer[T] = Reducer[String, T]
+  type BytesReducer[T] = Reducer[Buffer, T]
+
+  /** create a part reducer from a Monoid and a function transforming arrary of bytes to a value T */
+  def fromMonoid[P, M : Monoid](f: P => M) = new Reducer[P, M] {
+    type S = M
+    
+    def init: S =
+      Monoid[S].zero
+
+    def reduce(part: P, s: S): S =
+      Monoid[S].append(f(part), s)
+
+    def finalise(s: S): S =
+      s
+  }
+  /** fold from the left a Foldable container of lines */
+  def foldLeft[F[_] : Foldable, P, T](content: F[P], reducer: Reducer[P, T]): T =
+    reducer.finalise(Foldable[F].foldLeft(content, reducer.init)((s: reducer.S, p: P) => reducer.reduce(p, s)))
+
+}
+
+

--- a/notion-core/src/test/scala/com/ambiata/notion/core/BytesReducerSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/BytesReducerSpec.scala
@@ -1,0 +1,41 @@
+package com.ambiata.notion.core
+
+import java.security.MessageDigest
+
+import com.ambiata.disorder._
+import com.ambiata.mundane.data.Lists
+import com.ambiata.mundane.io.Checksum
+import com.ambiata.notion.core.Reducer._
+import com.ambiata.mundane.bytes.Buffer
+import scalaz._, Scalaz._
+import org.scalacheck._
+import org.specs2._
+
+class BytesReducerSpec extends Specification with ScalaCheck { def is = s2"""
+
+ A BytesReducer is used to reduce bytes when reading them from an input stream
+  the SHA1 BytesReducer returns the SHA1 for a list of lines $sha1
+  2 BytesReducers can be zipped together                     $zip
+"""
+
+  def sha1 = prop { strings: List100[N] =>
+    val lines = strings.value.map(_.value)
+    val linesAsString = Lists.prepareForFile(lines)
+    val sha1 = Checksum.toHexString(MessageDigest.getInstance("SHA-1").digest(linesAsString.getBytes("UTF-8")))
+    val bytes = linesAsString.getBytes("UTF-8")
+
+    Reducer.foldLeft(List(Buffer.wrapArray(bytes, 0, bytes.size)), BytesReducer.sha1) ==== sha1
+  }
+
+  def zip = prop { (strings: List100[N], r1: BytesReducer[String], r2: BytesReducer[String]) =>
+    val buffer = strings.value.collect { case s if s.value.nonEmpty =>
+      val bytes = s.value.getBytes("UTF-8")
+      Buffer.wrapArray(bytes, 0, bytes.size)
+    }
+    Reducer.foldLeft(buffer, r1 zip r2) == ((Reducer.foldLeft(buffer, r1), Reducer.foldLeft(buffer, r2)))
+  }
+
+  implicit def ArbitraryBytesReducer: Arbitrary[BytesReducer[String]] =
+    Arbitrary(Gen.const(BytesReducer.sha1))
+
+}

--- a/notion-core/src/test/scala/com/ambiata/notion/core/LineReducerSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/LineReducerSpec.scala
@@ -9,40 +9,32 @@ import com.ambiata.mundane.io.Checksum
 import org.specs2._
 import scalaz._, Scalaz._
 import org.scalacheck._
+import com.ambiata.notion.core.Reducer._
 
 class LineReducerSpec extends Specification with ScalaCheck { def is = s2"""
 
  A LineReducer is used to reduce lines when reading them from an input stream
   the linesNumber LineReducer returns the number of lines                  $linesNumber
   the tail LineReducer returns the last N lines                            $tail
-  the SHA1 LineReducer returns the SHA1 for the lines (including newlines) $sha1
 
   2 LineReducers can be zipped together                                    $zip
 """
 
   def linesNumber = prop { lines: List[N] =>
-    LineReducer.foldLeft(lines.map(_.value), LineReducer.linesNumber) ==== lines.size
+    Reducer.foldLeft(lines.map(_.value), LineReducer.linesNumber) ==== lines.size
   }
 
   def tail = prop { (strings: List[N], n: NaturalIntSmall) =>
     val lines = strings.map(_.value)
-    LineReducer.foldLeft(lines, LineReducer.tail(n.value)) ==== lines.drop(lines.size - n.value)
+    Reducer.foldLeft(lines, LineReducer.tail(n.value)) ==== lines.drop(lines.size - n.value)
   }.set(maxSize = 10)
-
-  def sha1 = prop { strings: List100[N] =>
-    val lines = strings.value.map(_.value)
-    val linesAsString = Lists.prepareForFile(lines)
-    val sha1 = Checksum.toHexString(MessageDigest.getInstance("SHA-1").digest(linesAsString.getBytes("UTF-8")))
-
-    LineReducer.foldLeft(lines, LineReducer.sha1) ==== sha1
-  }
 
   def zip = prop { (strings: List100[N], r1: LineReducer[_], r2: LineReducer[_]) =>
     val lines = strings.value.map(_.value)
-    LineReducer.foldLeft(lines, r1 zip r2) == ((LineReducer.foldLeft(lines, r1), LineReducer.foldLeft(lines, r2)))
+    Reducer.foldLeft(lines, r1 zip r2) == ((Reducer.foldLeft(lines, r1), Reducer.foldLeft(lines, r2)))
   }
 
   implicit def ArbitraryLineReducer: Arbitrary[LineReducer[_]] =
-    Arbitrary(Gen.oneOf(LineReducer.tail(10), LineReducer.linesNumber, LineReducer.sha1))
+    Arbitrary(Gen.oneOf(LineReducer.tail(10), LineReducer.linesNumber))
 
 }

--- a/notion-core/src/test/scala/com/ambiata/notion/core/ReducerSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/ReducerSpec.scala
@@ -1,0 +1,33 @@
+package com.ambiata.notion.core
+
+import com.ambiata.disorder._
+import com.ambiata.mundane.testing.Laws.functor
+import com.ambiata.notion.core.Reducer._
+import org.scalacheck.{Gen, Arbitrary}
+import Arbitrary._
+import org.specs2._
+import org.specs2.execute.AsResult
+import scalaz._, Scalaz._
+
+class ReducerSpec extends Specification with ScalaCheck { def is = s2"""
+
+ The Functor laws for Reducer must be satisfied ${functor.laws[Reducer[String, ?]]}
+
+"""
+
+  implicit def ArbitraryReducer: Arbitrary[Reducer[String, Int]] =
+   Arbitrary(Gen.const(LineReducer.linesNumber))
+
+  // 2 reducers are "equal" if they return the same values when folding lines
+  implicit def EqualReducer: scalaz.Equal[Reducer[String, Int]] =
+    new scalaz.Equal[Reducer[String, Int]] {
+      def equal(a1: Reducer[String, Int], a2: Reducer[String, Int]): Boolean =
+        AsResult {
+          prop { strings: List10[N] =>
+            val lines = strings.value.map(_.value)
+            Reducer.foldLeft(lines, a1) ==== Reducer.foldLeft(lines, a2)
+          }
+        }.isSuccess
+    }
+
+}

--- a/notion-core/src/test/scala/com/ambiata/notion/core/SequenceUtilSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/SequenceUtilSpec.scala
@@ -12,7 +12,7 @@ class SequenceUtilSpec extends Specification with ScalaCheck { def is = s2"""
 
   Sequence Util should be able to read and write
   ==============================================
-  from a locaiton    $location
+  from a location    $location
 
 """
   val conf = new Configuration

--- a/notion-core/src/test/scala/com/ambiata/notion/core/StoreTemporarySpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/StoreTemporarySpec.scala
@@ -4,6 +4,7 @@ import com.ambiata.disorder._
 import com.ambiata.mundane.control._
 import com.ambiata.mundane.testing.RIOMatcher._
 import org.specs2._
+import org.specs2.matcher.Parameters
 import scalaz._, Scalaz._
 
 class StoreTemporarySpec extends Specification with ScalaCheck { def is = s2"""
@@ -13,6 +14,8 @@ class StoreTemporarySpec extends Specification with ScalaCheck { def is = s2"""
    should clean up its own resources   $resources
    should always return a unique store $conflicts
 """
+  override implicit def defaultParameters: Parameters =
+    new Parameters(minTestsOk = 10, workers = 3, maxSize = 10)
 
   def resources = prop((st: StoreTemporary, id: Ident, data: String) => for {
     s <- st.store

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyInputFormatSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyInputFormatSpec.scala
@@ -8,6 +8,7 @@ import com.ambiata.saws.s3._
 import com.ambiata.saws.testing.Arbitraries._
 
 import org.specs2._
+import org.specs2.matcher.Parameters
 
 
 class DistCopyInputFormatSpec extends Specification with ScalaCheck { def is = s2"""
@@ -53,5 +54,9 @@ class DistCopyInputFormatSpec extends Specification with ScalaCheck { def is = s
         , DownloadMapping(b, h)
         , DownloadMapping(c, h)
       )), 2, s3Client, q)
-  } yield r ==== Workloads(Vector(Workload(Vector(0)), Workload(Vector(1, 2))))).set(minTestsOk = 20)
+  } yield r ==== Workloads(Vector(Workload(Vector(0)), Workload(Vector(1, 2)))))
+
+  override implicit def defaultParameters: Parameters =
+    new Parameters(minTestsOk = 10)
+
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -40,7 +40,8 @@ object build extends Build {
     id = "core"
     , base = file("notion-core")
     , settings = standardSettings ++ lib("core") ++ Seq[Settings](
-      name := "notion-core"
+      name := "notion-core",
+      addCompilerPlugin("org.spire-math" % "kind-projector_2.11" % "0.5.2")
     ) ++ Seq[Settings](libraryDependencies ++=
       depend.scalaz  ++
       depend.mundane ++

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -48,6 +48,7 @@ object depend {
 
   val argonaut    = Seq("io.argonaut"        %% "argonaut"     % "6.1-M4")
 
+  // for scala 2.11
   val resolvers = Seq(
     Resolver.sonatypeRepo("releases")
   , Resolver.sonatypeRepo("snapshots")
@@ -55,7 +56,8 @@ object depend {
   , Resolver.typesafeRepo("releases")
   , "cloudera" at "https://repository.cloudera.com/content/repositories/releases"
   , Resolver.url("ambiata-oss", new URL("https://ambiata-oss.s3.amazonaws.com"))(Resolver.ivyStylePatterns)
-  , "Scalaz Bintray Repo"  at "http://dl.bintray.com/scalaz/releases"
-  , "spray.io"             at "http://repo.spray.io"
+  , "bintray/scalaz"  at "http://dl.bintray.com/scalaz/releases"
+  , "bintray/non"     at "http://dl.bintray.com/non/maven"
+  , "spray.io"        at "http://repo.spray.io"
   )
 }

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -20,8 +20,8 @@ object depend {
     ExclusionRule(organization = "com.owtelse.codec")
   )) ++           Seq("com.ambiata"          %% "saws-testing"       % sawsVersion % "test->test")
 
-  val mundaneVersion = "1.2.1-20150310040336-0ef1d8c"
-  val mundane   = Seq("mundane-io", "mundane-control", "mundane-parse").map(c =>
+  val mundaneVersion = "1.2.1-20150323032355-3271ed9"
+  val mundane   = Seq("mundane-io", "mundane-control", "mundane-parse", "mundane-bytes").map(c =>
                       "com.ambiata"          %% c                 % mundaneVersion) ++
                   Seq("com.ambiata"          %% "mundane-io"      % mundaneVersion % "test->test") ++
                   Seq("com.ambiata"          %% "mundane-testing" % mundaneVersion % "test")


### PR DESCRIPTION
This is a follow-up from #59 where a SHA1 was computed based on a stream of string lines which is not a robust way to compute the SHA1 of a file.