### PR TITLE
Added a method to recreate a `Location` from an `ExecutionLocation`

### DIFF
--- a/notion-core/src/main/scala/com/ambiata/notion/core/InputOutputLocations.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/InputOutputLocations.scala
@@ -18,6 +18,10 @@ sealed trait ExecutionLocation {
 
   def render: String =
     fold(identity, identity)
+
+  /** @return a Location from the ExecutionLocation */
+  def location: Location =
+    fold(HdfsLocation.apply, LocalLocation.apply)
 }
 
 object ExecutionLocation {

--- a/notion-core/src/test/scala/com/ambiata/notion/core/Arbitraries.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/Arbitraries.scala
@@ -31,6 +31,13 @@ object Arbitraries {
   implicit def S3LocationArbitrary: Arbitrary[S3Location] =
     Arbitrary(S3PatternArbitrary.arbitrary.map { case S3Pattern(b, k) => S3Location(b, k) })
 
+
+  implicit def ArbitraryExecutionLocation: Arbitrary[ExecutionLocation] =
+    Arbitrary {
+      Gen.oneOf(arbitrary[HdfsLocation].map(hdfs => ExecutionLocation.HdfsExecutionLocation(hdfs.path)),
+        arbitrary[LocalLocation].map(local => ExecutionLocation.LocalExecutionLocation(local.path)))
+    }
+
   case class Path(path: String) {
     def onHdfs = "hdfs:///"+path
     def onLocal = "file:///"+path

--- a/notion-core/src/test/scala/com/ambiata/notion/core/ExecutionLocationSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/ExecutionLocationSpec.scala
@@ -1,0 +1,17 @@
+package com.ambiata.notion.core
+
+import org.scalacheck._, Arbitrary._
+import Arbitraries._
+import org.specs2._
+import scalaz._, Scalaz._
+
+class ExecutionLocationSpec extends Specification with ScalaCheck { def is = s2"""
+
+ An Execution location can be turned into
+  a location ${prop { location: Location =>
+    val executionLocation = ExecutionLocation.fromLocation(location)
+    executionLocation.map(_.location) ==== executionLocation.as(location)
+  }}
+
+"""
+}


### PR DESCRIPTION
This is useful when using the `LocationIO` api which expects to get Locations.