### PR TITLE
Return the input locations found when doing copyFiles

### DIFF
--- a/notion-core/src/test/scala/com/ambiata/notion/core/LocationIOSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/LocationIOSpec.scala
@@ -144,12 +144,14 @@ class LocationIOSpec extends Specification with ScalaCheck { def is = s2"""
                if (isDirectory) fileNames.traverseU(name => i.writeUtf8(f </> FileName.unsafe(name), content.value))
                else             i.writeUtf8(f, content.value)
       t     <- to.location
-      _     <- i.copyFiles(f, t, overwrite)
+      rs    <- i.copyFiles(f, t, overwrite)
+      ins   <- if (isDirectory) i.list(f) else RIO.ok(List(f))
       fs    <- if (isDirectory) i.list(t) else RIO.ok(List())
       isDir <- i.isDirectory(t)
     } yield
       if (isDirectory)
-        ("the target is a directory" ==> isDir) && (fs must haveSize(fileNames.size))
+        ("the target is a directory" ==> isDir) && (fs must haveSize(fileNames.size)) &&
+        ("the copied files are the list of files in the directory" ==> (rs ==== ins))
       else
         ("the target is not a directory" ==> !isDir) && (fs must haveSize(0))
   )

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopy.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopy.scala
@@ -19,20 +19,20 @@ object DistCopy {
    *
    * Don't copy files which have already been copied
    */
-  def downloadDirectory(from: S3Location, to: HdfsLocation, locationIO: LocationIO): RIO[Unit] =
+  def downloadDirectory(from: S3Location, to: HdfsLocation, locationIO: LocationIO): RIO[List[Location]] =
     for {
       fromAddresses <- S3Prefix(from.bucket, from.key).listAddress.execute(locationIO.s3Client)
       mappings      <- fromAddresses.traverseU(createDownloadMapping(to, locationIO))
       _             <- DistCopyJob.run(Mappings(mappings.toVector.flatten), distCopyConfiguration(locationIO))
-    } yield ()
+    } yield fromAddresses.map { case S3Address(b, k) => S3Location(b, k) }
 
   /** upload a large file by doing a distcopy from hdfs to s3 */
-  def uploadDirectory(from: HdfsLocation, to: S3Location, locationIO: LocationIO): RIO[Unit] =
+  def uploadDirectory(from: HdfsLocation, to: S3Location, locationIO: LocationIO): RIO[List[Location]] =
     for {
       fromPaths <- Hdfs.globFiles(new Path(from.path, "*")).run(locationIO.configuration)
       mappings  <- fromPaths.traverseU(createUploadMapping(to, locationIO))
       _         <- DistCopyJob.run(Mappings(mappings.toVector.flatten), distCopyConfiguration(locationIO))
-    } yield ()
+    } yield fromPaths.map(p => HdfsLocation(p.toString))
 
   /** @return true if the path exists */
   def pathExist(path: Path, locationIO: LocationIO): RIO[Boolean] =


### PR DESCRIPTION
Instead of returning `Unit` now `copyFiles` or `downloadDirectory`/`uploadDirectory` return the list of the locations for all files found under the input directory. This is useful to trace exactly what has been copied in applications using notion.