### PR TITLE
Fix bug with LocationIO.listHdfs returning locations with 'file:' prefixed

### DIFF
--- a/notion-core/src/main/scala/com/ambiata/notion/core/LocationIO.scala
+++ b/notion-core/src/main/scala/com/ambiata/notion/core/LocationIO.scala
@@ -31,7 +31,7 @@ case class LocationIO(configuration: Configuration, s3Client: AmazonS3Client) {
     Directories.list(local.dirPath).map(_.map(f => LocalLocation(f.path)))
 
   def listHdfs(hdfs: HdfsLocation): RIO[List[HdfsLocation]] =
-    Hdfs.globFilesRecursively(new Path(hdfs.path)).run(configuration).map(_.map(p => HdfsLocation(p.toString)))
+    Hdfs.globFilesRecursively(new Path(hdfs.path)).run(configuration).map(_.map(p => HdfsLocation(p.toUri.getPath)))
 
   def listS3(s3: S3Location): RIO[List[S3Location]] =
     S3Pattern(s3.bucket, s3.key).listKeys.execute(s3Client).map(_.map(k => S3Location(s3.bucket,  k)))

--- a/notion-core/src/test/scala/com/ambiata/notion/core/LocationIOSpec.scala
+++ b/notion-core/src/test/scala/com/ambiata/notion/core/LocationIOSpec.scala
@@ -115,7 +115,7 @@ class LocationIOSpec extends Specification with ScalaCheck { def is = s2"""
     _ <- i.writeUtf8(p </> FilePath.unsafe(dp.second.value), data)
     r <- i.list(p)
     l = r.length
-  } yield r.map(_.render.split("/").last).toSet -> l ==== Set(dp.first.value, dp.second.value) -> 2)
+  } yield r.toSet -> l ==== Set(dp.first.value, dp.second.value).map(FileName.unsafe).map(p </> _) -> 2)
 
   def exists = prop((loc: LocationTemporary, data: String) => for {
     p <- loc.location


### PR DESCRIPTION
Found this bug when using `LocationIO.listHdfs`. If `Path` has a scheme set, `Path.toString` will keep it as part of the string. This happens with the paths return from `Hdfs.globFilesRecursively`

@nhibberd @markhibberd 