### PR TITLE
Pass additional dimensions to a distcopy stats. fixes #87

### DIFF
--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyStats.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyStats.scala
@@ -1,72 +1,98 @@
 package com.ambiata.notion.distcopy
 
-import com.ambiata.com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
 import com.ambiata.com.amazonaws.services.cloudwatch.model._
-import com.ambiata.saws.core._
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapreduce.{Mapper, Counter}
-
+import com.ambiata.mundane.control.RIO
+import com.ambiata.saws.core.CloudWatchAction
+import CloudWatchAction._
 import scala.collection.JavaConverters._
-
+import com.ambiata.mundane.io._, MemoryConversions._
 import scalaz._, Scalaz._
 
 case class DistCopyStats(name: String, counts: Map[String, Long])
 
 object DistCopyStats {
 
-  def publish(stats: DistCopyStats): CloudWatchAction[Unit] = {
-    val totalBytesUploaded = stats.counts.get("total.bytes.uploaded")
-    val totalMegabytesUploaded = stats.counts.get("total.megabytes.uploaded")
-    val totalGigabytesUploaded = stats.counts.get("total.gigabytes.uploaded")
-    val totalFilesUploaded = stats.counts.get("total.files.uploaded")
-    val totalBytesDownloaded = stats.counts.get("total.bytes.downloaded")
-    val totalMegabytesDownloaded = stats.counts.get("total.megabytes.downloaded")
-    val totalGigabytesDownloaded = stats.counts.get("total.gigabytes.downloaded")
-    val totalFilesDownloaded = stats.counts.get("total.files.downloaded")
-    val retryCounter = stats.counts.get("total.files.retried")
+  val UPLOADED_BYTES   = "uploaded.bytes"
+  val DOWNLOADED_BYTES = "downloaded.bytes"
+  val UPLOADED_FILES   = "uploaded.files"
+  val DOWNLOADED_FILES = "downloaded.files"
+  val RETRIED_FILES    = "retried.files"
 
+  def publish(stats: DistCopyStats, namespace: Namespace, customDimensions: List[MetricDimension]): CloudWatchAction[Unit] =
+    for {
+      dimensions <- fromRIO(RIO.fromDisjunctionString(makeDimensions(stats, customDimensions)))
+      c          <- client
+      put        =  makePutMetricDataRequest(stats, namespace, dimensions)
+      _          <- safe(c.putMetricData(put))
+    } yield ()
+
+  def makePutMetricDataRequest(stats: DistCopyStats, namespace: Namespace, dimensions: List[Dimension]): PutMetricDataRequest = {
     val put: PutMetricDataRequest = new PutMetricDataRequest()
-    put.withNamespace("Ambiata/View")
+    put.withNamespace(namespace.n)
 
-    val dim: Dimension = new Dimension()
-    dim.setName("Hadoop_Job_Id")
-    dim.setValue(stats.name)
+    val metrics: List[MetricDatum] = List(
+        stats.counts.get(UPLOADED_BYTES  ).map(v => memoryMetrics(UPLOADED_BYTES,  v.bytes)).getOrElse(Nil)
+      , stats.counts.get(DOWNLOADED_BYTES).map(v => memoryMetrics(DOWNLOADED_BYTES, v.bytes)).getOrElse(Nil)
+      , stats.counts.get(UPLOADED_FILES  ).map(v => countMetric (UPLOADED_FILES,  v)).toList
+      , stats.counts.get(DOWNLOADED_FILES).map(v => countMetric (DOWNLOADED_FILES, v)).toList
+      , stats.counts.get(RETRIED_FILES   ).map(v => countMetric (RETRIED_FILES, v)).toList
+    ).flatten.map(setDimensions(dimensions))
 
-    val md: List[MetricDatum] = List(
-        totalBytesUploaded.map(metric("UploadByteCount", _, dim))
-      , totalBytesUploaded.map(metric("UploadByteCount", _, totals("bytes.uploaded")))
-      , totalMegabytesUploaded.map(metric("UploadMegabyteCount", _, totals("megabytes.uploaded")))
-      , totalGigabytesUploaded.map(metric("UploadGigabyteCount", _, totals("gigabytes.uploaded")))
-      , totalBytesDownloaded.map(metric("DownloadByteCount", _, dim))
-      , totalBytesDownloaded.map(metric("DownloadByteCount", _, totals("bytes.downloaded")))
-      , totalMegabytesDownloaded.map(metric("DownloadMegabyteCount", _, totals("megabytes.downloaded")))
-      , totalGigabytesDownloaded.map(metric("DownloadGigabyteCount", _, totals("gigabytes.downloaded")))
-      , retryCounter.map(metric("TotalRetries", _, totals("retry")))
-      , totalFilesUploaded.map(metric("TotalFilesUploaded", _, totals("files.uploaded")))
-      , totalFilesDownloaded.map(metric("TotalFilesDownloaded", _, totals("files.downloaded")))
-    ).flatten
-    md.foreach(put.withMetricData(_))
-    CloudWatchAction(_.putMetricData(put))
+    put.withMetricData(metrics.asJavaCollection)
   }
 
-  def totals(s: String): Dimension = {
-    val dim: Dimension = new Dimension()
-    dim.setName("Totals")
-    dim.setValue(s)
-    dim
+  /**
+   * Make dimensions for distcopy stats: 10 dimensions per metric max are allowed by CloudWatch
+   */
+  def makeDimensions(stats: DistCopyStats, customDimensions: List[MetricDimension]): String \/ List[Dimension] = {
+    val hadoopJobId: Dimension = new Dimension
+    hadoopJobId.setName("hadoop-job-id")
+    hadoopJobId.setValue(stats.name)
+
+    val dimensions = hadoopJobId :: customDimensions.map(_.toDimension)
+    if (dimensions.size > 10) s"""Too many dimensions for a metric. Should be less or equal to 10. Got: ${dimensions.mkString("\n")}""".left
+    else dimensions.right
   }
 
-  def metric(name: String, value: Long, dim: Dimension): MetricDatum = {
-    val metric: MetricDatum = new MetricDatum()
-    metric.setMetricName(name)
-    metric.setUnit(StandardUnit.Count)
-    metric.setValue(value)
-    metric.setDimensions(dim.pure[List].asJava)
+  /** set the dimensions on the metric object */
+  def setDimensions(dimensions: List[Dimension]): MetricDatum => MetricDatum = (metric: MetricDatum) => {
+    metric.setDimensions(dimensions.asJavaCollection)
     metric
   }
 
-  def empty: DistCopyStats = {
+  def memoryMetrics(name: String, value: BytesQuantity): List[MetricDatum] = {
+    List(
+        value             -> StandardUnit.Bytes
+      , value.toMegabytes -> StandardUnit.Megabytes
+      , value.toGigabytes -> StandardUnit.Gigabytes
+      , value.toTerabytes -> StandardUnit.Terabytes
+    ).map { case (v, u) => createMetricDatum(name, v.value.toDouble, u) }
+  }
+
+  def countMetric(name: String, value: Long): MetricDatum =
+    createMetricDatum(name, value.toDouble, StandardUnit.Count)
+
+  def createMetricDatum(name: String, value: Double, unit: StandardUnit) = {
+    val metric = new MetricDatum
+    metric.setMetricName(name)
+    metric.setValue(value)
+    metric.setUnit(unit)
+    metric
+  }
+
+  def empty: DistCopyStats =
     DistCopyStats("empty", Map.empty)
+
+}
+
+case class Namespace(n: String) extends AnyVal
+
+case class MetricDimension(name: String, value: String) extends {
+  def toDimension: Dimension = {
+    val d: Dimension = new Dimension
+    d.setName(name)
+    d.setValue(value)
+    d
   }
 }
+


### PR DESCRIPTION
I opening and closing this PR just to keep it as a reference. The idea was to have `view` and `ivory` pass `AMBIATA_CUSTOMER` and `AMBIATA_CONTEXT` but this should all probably be done by using ambiata/exsum.scala.
