### PR TITLE
Removed CloudWatch support in Distcopy

### DIFF
--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyStats.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyStats.scala
@@ -1,72 +1,98 @@
 package com.ambiata.notion.distcopy
 
-import com.ambiata.com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
 import com.ambiata.com.amazonaws.services.cloudwatch.model._
-import com.ambiata.saws.core._
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapreduce.{Mapper, Counter}
-
+import com.ambiata.mundane.control.RIO
+import com.ambiata.saws.core.CloudWatchAction
+import CloudWatchAction._
 import scala.collection.JavaConverters._
-
+import com.ambiata.mundane.io._, MemoryConversions._
 import scalaz._, Scalaz._
 
 case class DistCopyStats(name: String, counts: Map[String, Long])
 
 object DistCopyStats {
 
-  def publish(stats: DistCopyStats): CloudWatchAction[Unit] = {
-    val totalBytesUploaded = stats.counts.get("total.bytes.uploaded")
-    val totalMegabytesUploaded = stats.counts.get("total.megabytes.uploaded")
-    val totalGigabytesUploaded = stats.counts.get("total.gigabytes.uploaded")
-    val totalFilesUploaded = stats.counts.get("total.files.uploaded")
-    val totalBytesDownloaded = stats.counts.get("total.bytes.downloaded")
-    val totalMegabytesDownloaded = stats.counts.get("total.megabytes.downloaded")
-    val totalGigabytesDownloaded = stats.counts.get("total.gigabytes.downloaded")
-    val totalFilesDownloaded = stats.counts.get("total.files.downloaded")
-    val retryCounter = stats.counts.get("total.files.retried")
+  val UPLOADED_BYTES   = "uploaded.bytes"
+  val DOWNLOADED_BYTES = "downloaded.bytes"
+  val UPLOADED_FILES   = "uploaded.files"
+  val DOWNLOADED_FILES = "downloaded.files"
+  val RETRIED_FILES    = "retried.files"
 
+  def publish(stats: DistCopyStats, namespace: Namespace, customDimensions: List[MetricDimension]): CloudWatchAction[Unit] =
+    for {
+      dimensions <- fromRIO(RIO.fromDisjunctionString(makeDimensions(stats, customDimensions)))
+      c          <- client
+      put        =  makePutMetricDataRequest(stats, namespace, dimensions)
+      _          <- safe(c.putMetricData(put))
+    } yield ()
+
+  def makePutMetricDataRequest(stats: DistCopyStats, namespace: Namespace, dimensions: List[Dimension]): PutMetricDataRequest = {
     val put: PutMetricDataRequest = new PutMetricDataRequest()
-    put.withNamespace("Ambiata/View")
+    put.withNamespace(namespace.n)
 
-    val dim: Dimension = new Dimension()
-    dim.setName("Hadoop_Job_Id")
-    dim.setValue(stats.name)
+    val metrics: List[MetricDatum] = List(
+        stats.counts.get(UPLOADED_BYTES  ).map(v => memoryMetrics(UPLOADED_BYTES,  v.bytes)).getOrElse(Nil)
+      , stats.counts.get(DOWNLOADED_BYTES).map(v => memoryMetrics(DOWNLOADED_BYTES, v.bytes)).getOrElse(Nil)
+      , stats.counts.get(UPLOADED_FILES  ).map(v => countMetric (UPLOADED_FILES,  v)).toList
+      , stats.counts.get(DOWNLOADED_FILES).map(v => countMetric (DOWNLOADED_FILES, v)).toList
+      , stats.counts.get(RETRIED_FILES   ).map(v => countMetric (RETRIED_FILES, v)).toList
+    ).flatten.map(setDimensions(dimensions))
 
-    val md: List[MetricDatum] = List(
-        totalBytesUploaded.map(metric("UploadByteCount", _, dim))
-      , totalBytesUploaded.map(metric("UploadByteCount", _, totals("bytes.uploaded")))
-      , totalMegabytesUploaded.map(metric("UploadMegabyteCount", _, totals("megabytes.uploaded")))
-      , totalGigabytesUploaded.map(metric("UploadGigabyteCount", _, totals("gigabytes.uploaded")))
-      , totalBytesDownloaded.map(metric("DownloadByteCount", _, dim))
-      , totalBytesDownloaded.map(metric("DownloadByteCount", _, totals("bytes.downloaded")))
-      , totalMegabytesDownloaded.map(metric("DownloadMegabyteCount", _, totals("megabytes.downloaded")))
-      , totalGigabytesDownloaded.map(metric("DownloadGigabyteCount", _, totals("gigabytes.downloaded")))
-      , retryCounter.map(metric("TotalRetries", _, totals("retry")))
-      , totalFilesUploaded.map(metric("TotalFilesUploaded", _, totals("files.uploaded")))
-      , totalFilesDownloaded.map(metric("TotalFilesDownloaded", _, totals("files.downloaded")))
-    ).flatten
-    md.foreach(put.withMetricData(_))
-    CloudWatchAction(_.putMetricData(put))
+    put.withMetricData(metrics.asJavaCollection)
   }
 
-  def totals(s: String): Dimension = {
-    val dim: Dimension = new Dimension()
-    dim.setName("Totals")
-    dim.setValue(s)
-    dim
+  /**
+   * Make dimensions for distcopy stats: 10 dimensions per metric max are allowed by CloudWatch
+   */
+  def makeDimensions(stats: DistCopyStats, customDimensions: List[MetricDimension]): String \/ List[Dimension] = {
+    val hadoopJobId: Dimension = new Dimension
+    hadoopJobId.setName("hadoop-job-id")
+    hadoopJobId.setValue(stats.name)
+
+    val dimensions = hadoopJobId :: customDimensions.map(_.toDimension)
+    if (dimensions.size > 10) s"""Too many dimensions for a metric. Should be less or equal to 10. Got: ${dimensions.mkString("\n")}""".left
+    else dimensions.right
   }
 
-  def metric(name: String, value: Long, dim: Dimension): MetricDatum = {
-    val metric: MetricDatum = new MetricDatum()
-    metric.setMetricName(name)
-    metric.setUnit(StandardUnit.Count)
-    metric.setValue(value)
-    metric.setDimensions(dim.pure[List].asJava)
+  /** set the dimensions on the metric object */
+  def setDimensions(dimensions: List[Dimension]): MetricDatum => MetricDatum = (metric: MetricDatum) => {
+    metric.setDimensions(dimensions.asJavaCollection)
     metric
   }
 
-  def empty: DistCopyStats = {
+  def memoryMetrics(name: String, value: BytesQuantity): List[MetricDatum] = {
+    List(
+        value             -> StandardUnit.Bytes
+      , value.toMegabytes -> StandardUnit.Megabytes
+      , value.toGigabytes -> StandardUnit.Gigabytes
+      , value.toTerabytes -> StandardUnit.Terabytes
+    ).map { case (v, u) => createMetricDatum(name, v.value.toDouble, u) }
+  }
+
+  def countMetric(name: String, value: Long): MetricDatum =
+    createMetricDatum(name, value.toDouble, StandardUnit.Count)
+
+  def createMetricDatum(name: String, value: Double, unit: StandardUnit) = {
+    val metric = new MetricDatum
+    metric.setMetricName(name)
+    metric.setValue(value)
+    metric.setUnit(unit)
+    metric
+  }
+
+  def empty: DistCopyStats =
     DistCopyStats("empty", Map.empty)
+
+}
+
+case class Namespace(n: String) extends AnyVal
+
+case class MetricDimension(name: String, value: String) extends {
+  def toDimension: Dimension = {
+    val d: Dimension = new Dimension
+    d.setName(name)
+    d.setValue(value)
+    d
   }
 }
+

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/Mapping.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/Mapping.scala
@@ -3,7 +3,16 @@ package com.ambiata.notion.distcopy
 import com.ambiata.saws.s3.S3Address
 import org.apache.hadoop.fs.Path
 
-sealed trait Mapping
+sealed trait Mapping {
+  def render: String
+}
 
-case class DownloadMapping(from: S3Address, to: Path) extends Mapping
-case class UploadMapping(from: Path, to: S3Address) extends Mapping
+case class DownloadMapping(from: S3Address, to: Path) extends Mapping {
+  def render: String =
+    s"$from,$to"
+}
+
+case class UploadMapping(from: Path, to: S3Address) extends Mapping {
+  def render: String =
+    s"$from,$to"
+}

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopySpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopySpec.scala
@@ -94,7 +94,7 @@ class DistCopySpec extends AwsScalaCheckSpec(tests = 5) { def is = s2"""
       c <- ConfigurationTemporary.random.conf
       d = DistCopyConfiguration(c, Clients.s3, DistCopyParameters.createDefault(mappersNumber = 1))
       r <- DistCopyJob.run(Mappings(Vector.empty), d)
-    } yield r must_==(DistCopyStats.empty)
+    } yield r must beNone
 
   /**
    * HELPERS

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyStatsSpecs.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyStatsSpecs.scala
@@ -1,0 +1,35 @@
+package com.ambiata.notion.distcopy
+
+import com.ambiata.saws.cw._
+import com.ambiata.saws.cw.Arbitraries._
+import org.specs2._
+import DistCopyStats._
+
+class DistCopyStatsSpecs extends Specification with ScalaCheck { def is = s2"""
+
+  Statistics can be built from counts
+    memory stats $memoryStats
+    file stats   $fileStats
+
+"""
+
+  def memoryStats = prop { (jobId: String, bytes: Long, ts: Timestamp) =>
+    val stats = DistCopyStats(jobId, Map(UPLOADED_BYTES -> bytes), ts.value)
+
+    stats.memoryStats(UPLOADED_BYTES) === List(
+      ("uploaded.bytes",     StatisticsData(bytes.toDouble, Bytes))
+    , ("uploaded.megabytes", StatisticsData((bytes / 1024 / 1024).toDouble, Megabytes))
+    , ("uploaded.gigabytes", StatisticsData((bytes / 1024 / 1024 / 1024).toDouble, Gigabytes))
+    )
+  }
+
+  def fileStats = prop { (jobId: String, files: Long, ts: Timestamp) =>
+    val stats = DistCopyStats(jobId, Map(UPLOADED_FILES -> files), ts.value)
+
+    stats.countStat(UPLOADED_FILES) === Some(
+        ("uploaded.files",     StatisticsData(files.toDouble, Count))
+    )
+  }
+
+
+}

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/MappingsSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/MappingsSpec.scala
@@ -16,7 +16,16 @@ class MappingsSpec extends Specification with ScalaCheck { def is = s2"""
 
   ${ prop((m: Mappings) => Mappings.fromThrift(m.toThrift) ==== m) }
 
+ isEmpty  $isEmpty
+ distinct $distinct
+
 """
+
+  def isEmpty =
+    prop((mappings: Mappings) => mappings.isEmpty === mappings.mappings.isEmpty)
+
+  def distinct =
+    prop((mappings: Mappings) => mappings.distinct === Mappings(mappings.mappings.distinct))
 
   implicit def MappingsArbitrary: Arbitrary[Mappings] =
     Arbitrary(Gen.listOf(arbitrary[Mapping]).flatMap(i => Mappings(i.toVector)))

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -13,12 +13,14 @@ object depend {
                       "org.specs2"           %% "specs2-matcher-extra",
                       "org.specs2"           %% "specs2-scalacheck").map(_ % "2.4.5" % "test")
 
-  val sawsVersion = "1.2.1-20150721073540-3b8a713"
-  val saws      = Seq("com.ambiata"          %% "saws-s3"            % sawsVersion excludeAll(
+  val sawsVersion = "1.2.1-20150908051337-105d82b"
+  val saws      = Seq(
+    "com.ambiata"          %% "saws-s3",
+    "com.ambiata"          %% "saws-cw").map(_ % sawsVersion excludeAll(
     ExclusionRule(organization = "org.specs2"),
     ExclusionRule(organization = "javax.mail"),
-    ExclusionRule(organization = "com.owtelse.codec")
-  )) ++           Seq("com.ambiata"          %% "saws-testing"       % sawsVersion % "test->test")
+    ExclusionRule(organization = "com.owtelse.codec"))) ++
+    Seq("com.ambiata"          %% "saws-testing"       % sawsVersion % "test->test")
 
   val mundaneVersion = "1.2.1-20150323032355-3271ed9"
   val mundane   = Seq("mundane-io", "mundane-control", "mundane-parse", "mundane-bytes").map(c =>


### PR DESCRIPTION
Publishing CloudWatch metrics in `view` and `ivory` is now supported by `exsum`. The main advantage is the persistence of statistics so that we can analyse data over a long time period.