### PR TITLE
Use poacher hdfs api in upload/download mappings

### DIFF
--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyInputFormat.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyInputFormat.scala
@@ -84,7 +84,7 @@ object DistCopyInputFormat {
 
   def size(z: (Mapping, Int), client: AmazonS3Client, conf: Configuration): RIO[Long] = z._1 match {
     case DownloadMapping(from, _) => from.size.execute(client)
-    case UploadMapping(from, _)   => HdfsPath.fromPath(from).sizeOrFail.run(conf).map(_.value)
+    case UploadMapping(from, _)   => from.sizeOrFail.run(conf).map(_.value)
   }
 
   def calc(mappings: Mappings, mappers: Int, client: AmazonS3Client, conf: Configuration): RIO[Workloads] = for {

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/Mapping.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/Mapping.scala
@@ -1,18 +1,18 @@
 package com.ambiata.notion.distcopy
 
+import com.ambiata.poacher.hdfs.HdfsPath
 import com.ambiata.saws.s3.S3Address
-import org.apache.hadoop.fs.Path
 
 sealed trait Mapping {
   def render: String
 }
 
-case class DownloadMapping(from: S3Address, to: Path) extends Mapping {
+case class DownloadMapping(from: S3Address, to: HdfsPath) extends Mapping {
   def render: String =
-    s"$from,$to"
+    s"s3://${from.bucket}/${from.key},hdfs://${to.path.path}"
 }
 
-case class UploadMapping(from: Path, to: S3Address) extends Mapping {
+case class UploadMapping(from: HdfsPath, to: S3Address) extends Mapping {
   def render: String =
-    s"$from,$to"
+    s"hdfs://${from.path.path},s3://${to.bucket}/${to.key}"
 }

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/Mappings.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/Mappings.scala
@@ -1,8 +1,7 @@
 package com.ambiata.notion.distcopy
 
+import com.ambiata.poacher.hdfs._
 import com.ambiata.saws.s3._
-
-import org.apache.hadoop.fs.Path
 
 import scala.collection.JavaConverters._
 import scalaz.Monoid
@@ -11,9 +10,9 @@ case class Mappings(mappings: Vector[Mapping]) {
   def toThrift: MappingsLookup =
     new MappingsLookup(mappings.toList.map({
       case UploadMapping(f, t) =>
-        MappingLookup.upload(new UploadMappingLookup(f.toString, t.bucket, t.key))
+        MappingLookup.upload(new UploadMappingLookup(f.path.path, t.bucket, t.key))
       case DownloadMapping(f, t) =>
-        MappingLookup.download(new DownloadMappingLookup(f.bucket, f.key, t.toString))
+        MappingLookup.download(new DownloadMappingLookup(f.bucket, f.key, t.path.path))
     }).asJava)
 
   def isEmpty: Boolean =
@@ -41,10 +40,10 @@ object Mappings {
     Mappings(m.mappings.asScala.toVector.map(m =>
       if (m.isSetUpload) {
         val up = m.getUpload
-        UploadMapping(new Path(up.path), S3Address(up.bucket, up.key))
+        UploadMapping(HdfsPath.fromString(up.path), S3Address(up.bucket, up.key))
       } else {
         val d = m.getDownload
-        DownloadMapping(S3Address(d.bucket, d.key), new Path(d.path))
+        DownloadMapping(S3Address(d.bucket, d.key), HdfsPath.fromString(d.path))
       }
     ))
 }

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyDownloadSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyDownloadSpec.scala
@@ -45,7 +45,7 @@ Download files from S3 to HDFS
     a <- s3.address.execute(s3Client)
     p <- hdfs.path.run(c)
     _ <- a.put(data).execute(s3Client)
-    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p.toHPath))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p))), distCopyConf(c, s3Client))
     s <- p.read.run(c)
   } yield s must beSome(data))
 
@@ -56,7 +56,7 @@ Download files from S3 to HDFS
     p <- hdfs.path.run(c)
     o <- hdfs.path.run(c)
     _ <- List(a, b).traverse(_.put(data).execute(s3Client))
-    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p.toHPath), DownloadMapping(b, o.toHPath))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p), DownloadMapping(b, o))), distCopyConf(c, s3Client))
     r <- p.read.run(c)
     z <- o.read.run(c)
   } yield r -> z ==== data.some -> data.some)
@@ -70,7 +70,7 @@ Download files from S3 to HDFS
     x = h | Component.unsafe(d.first.value)
     y = h | Component.unsafe(d.second.value) | Component.unsafe(d.first.value)
     _ <- List(o, t).traverse(_.put(data).execute(s3Client))
-    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(o, x.toHPath), DownloadMapping(t, y.toHPath))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(o, x), DownloadMapping(t, y))), distCopyConf(c, s3Client))
     r <- x.read.run(c)
     z <- y.read.run(c)
   } yield r -> z ==== data.some -> data.some)
@@ -79,7 +79,7 @@ Download files from S3 to HDFS
     c <- ConfigurationTemporary.random.conf
     a <- s3.address.execute(s3Client)
     p <- hdfs.path.run(c)
-    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p.toHPath))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p))), distCopyConf(c, s3Client))
   } yield ()) must beFail)
 
   def targetExists = prop((s3: S3Temporary, hdfs: HdfsTemporary, data: S) => (for {
@@ -88,6 +88,6 @@ Download files from S3 to HDFS
     p <- hdfs.path.run(c)
     _ <- a.put(data.value).execute(s3Client)
     _ <- p.write(data.value).run(c)
-    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p.toHPath))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(DownloadMapping(a, p))), distCopyConf(c, s3Client))
   } yield ()) must beFail)
 }

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyInputFormatSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyInputFormatSpec.scala
@@ -33,9 +33,9 @@ class DistCopyInputFormatSpec extends Specification with ScalaCheck { def is = s
     _ <- c.write("c").run(q)
     r <- DistCopyInputFormat.calc(
       Mappings(Vector(
-          UploadMapping(a.toHPath, s)
-        , UploadMapping(b.toHPath, s)
-        , UploadMapping(c.toHPath, s)
+          UploadMapping(a, s)
+        , UploadMapping(b, s)
+        , UploadMapping(c, s)
       )), 2, s3Client, q)
   } yield r ==== Workloads(Vector(Workload(Vector(1)), Workload(Vector(0, 2)))))
 
@@ -50,9 +50,9 @@ class DistCopyInputFormatSpec extends Specification with ScalaCheck { def is = s
     _ <- c.put("c").execute(s3Client)
     r <- DistCopyInputFormat.calc(
       Mappings(Vector(
-          DownloadMapping(a, h.toHPath)
-        , DownloadMapping(b, h.toHPath)
-        , DownloadMapping(c, h.toHPath)
+          DownloadMapping(a, h)
+        , DownloadMapping(b, h)
+        , DownloadMapping(c, h)
       )), 2, s3Client, q)
   } yield r ==== Workloads(Vector(Workload(Vector(0)), Workload(Vector(1, 2)))))
 

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopySyncSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopySyncSpec.scala
@@ -33,7 +33,7 @@ Syncing files between S3 and HDFS
     y <- hdfs.path.run(c)
     _ <- a.put(data.value).execute(s3Client)
     _ <- x.write(data.value).run(c)
-    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(x.toHPath, b), DownloadMapping(a, y.toHPath))),
+    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(x, b), DownloadMapping(a, y))),
            DistCopyConfiguration(c, s3Client, DistCopyParameters.createDefault(mappersNumber = 1)))
     i <- b.get.execute(s3Client)
     o <- y.read.run(c)

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyUploadSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/DistCopyUploadSpec.scala
@@ -45,7 +45,7 @@ Upload files from HDFS to S3
     a <- s3.address.execute(s3Client)
     p <- hdfs.path.run(c)
     _ <- p.write(data.value).run(c)
-    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(p.toHPath, a))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(p, a))), distCopyConf(c, s3Client))
     r <- a.get.execute(s3Client)
   } yield r ==== data.value)
 
@@ -56,7 +56,7 @@ Upload files from HDFS to S3
     x <- hdfs.path.run(c)
     y <- hdfs.path.run(c)
     _ <- List(x, y).traverse(_.write(data).run(c))
-    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(x.toHPath, a), UploadMapping(y.toHPath, b))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(x, a), UploadMapping(y, b))), distCopyConf(c, s3Client))
     r <- a.get.execute(s3Client)
     z <- b.get.execute(s3Client)
   } yield r -> z ==== data -> data)
@@ -65,7 +65,7 @@ Upload files from HDFS to S3
     c <- ConfigurationTemporary.random.conf
     a <- s3.address.execute(s3Client)
     p <- hdfs.path.run(c)
-    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(p.toHPath, a))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(p, a))), distCopyConf(c, s3Client))
   } yield ()) must beFail)
 
   def targetExists = propNoShrink((s3: S3Temporary, hdfs: HdfsTemporary) => (for {
@@ -74,7 +74,7 @@ Upload files from HDFS to S3
     p <- hdfs.path.run(c)
     _ <- p.write("").run(c)
     _ <- a.put("").execute(s3Client)
-    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(p.toHPath, a))), distCopyConf(c, s3Client))
+    _ <- DistCopyJob.run(Mappings(Vector(UploadMapping(p, a))), distCopyConf(c, s3Client))
   } yield ()) must beFail)
 
 }

--- a/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/MappingsSpec.scala
+++ b/notion-distcopy/src/test/scala/com/ambiata/notion/distcopy/MappingsSpec.scala
@@ -1,10 +1,10 @@
 package com.ambiata.notion.distcopy
 
-import com.ambiata.disorder._
+import com.ambiata.mundane.path._
+import com.ambiata.mundane.path.Arbitraries._
+import com.ambiata.poacher.hdfs._
 import com.ambiata.saws.testing.Arbitraries._
 import com.ambiata.saws.s3._
-
-import org.apache.hadoop.fs.Path
 
 import org.scalacheck._, Arbitrary._
 import org.specs2._
@@ -32,8 +32,7 @@ class MappingsSpec extends Specification with ScalaCheck { def is = s2"""
 
   implicit def MappingArbitrary: Arbitrary[Mapping] = Arbitrary(for {
     s <- arbitrary[S3Address]
-    q <- arbitrary[NonEmptyString]
-    p = new Path(q.value.replace(':', ' '))
+    p <- arbitrary[Path].map(HdfsPath.apply)
     m <- Gen.oneOf(Gen.const(UploadMapping(p, s)), Gen.const(DownloadMapping(s, p)))
   } yield m)
 

--- a/project/depend.scala
+++ b/project/depend.scala
@@ -39,7 +39,7 @@ object depend {
     if (version.contains("mr1"))
       Seq("com.ambiata" %% "poacher" % "1.0.0-mr1-20151013034225-ec555dc" % "compile->compile;test->test") ++ hadoop(version)
     else if (version.contains("yarn"))
-      Seq("com.ambiata" %% "poacher" % "1.0.0-yarn-20160222041120-06eddb8" % "compile->compile;test->test") ++ hadoop(version)
+      Seq("com.ambiata" %% "poacher" % "1.0.0-yarn-20160418021427-15dc70b" % "compile->compile;test->test") ++ hadoop(version)
     else
       sys.error(s"unsupported poacher version, can not build for $version")
 


### PR DESCRIPTION
@markhibberd @nhibberd Noticed the hadoop `Path` was still being used in the `UploadMapping` and `DownloadMapping` classes, so have changed them to the poacher version.