### PR TITLE
Improve control of overwrite semantics.

### DIFF
--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyConfiguration.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyConfiguration.scala
@@ -36,8 +36,11 @@ object DistCopyConfiguration {
  *
  *  - a number of mappers: this depends on the number and size of files being transferred
  *  - mappers parameters governing the transfer of each file between S3 and Hdfs
+ *  - crossValidate whether or not to perform cross-validate checks for overwriting files,
+ *    this defaults to true because it is safer to check, but it does have a significant
+ *    performance and reliability cost. It can be disabled with adequate pre-checks.
  */
-case class DistCopyParameters(mappersNumber: Int, mapperParameters: DistCopyMapperParameters) {
+case class DistCopyParameters(mappersNumber: Int, mapperParameters: DistCopyMapperParameters, crossValidate: Boolean) {
   def retryCount: Int = mapperParameters.retryCount
   def partSize: BytesQuantity = mapperParameters.partSize
   def readLimit: BytesQuantity = mapperParameters.readLimit
@@ -48,6 +51,7 @@ object DistCopyParameters {
   def createDefault(mappersNumber: Int) = DistCopyParameters(
       mappersNumber
     , DistCopyMapperParameters.Default
+    , true
   )
 }
 
@@ -57,7 +61,7 @@ object DistCopyParameters {
  * For transferring files of various sizes
  *  experimentation suggests values of
  *
- *    retryCount = 3
+ *    retryCount = 10
  *    partSize = 100.mb
  *    readLimit = 100.mb
  *    multipartUploadThreshold = 100.mb
@@ -71,10 +75,9 @@ case class DistCopyMapperParameters(
 
 object DistCopyMapperParameters {
   val Default = DistCopyMapperParameters(
-      3
+      10
     , 100.mb
     , 100.mb
     , 100.mb
   )
 }
-

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
@@ -53,7 +53,8 @@ object DistCopyJob {
         job.getConfiguration.setInt(ReadLimit, conf.readLimit.toBytes.value.toInt)
         job.getConfiguration.setLong(MultipartUploadThreshold, conf.multipartUploadThreshold.toBytes.value)
         job.getConfiguration.setBoolean(CrossValidate, conf.parameters.crossValidate)
-        job.getConfiguration.setBoolean(S3Endpoint, conf.client.getEndpoint)
+        // Is there another way to get the endpoint?
+        job.getConfiguration.set(S3Endpoint, conf.client.getRegion.toAWSRegion.getServiceEndpoint("s3"))
       })
       n   = Math.min(mappings.mappings.length, conf.mappersNumber)
       _   <- DistCopyInputFormat.setMappings(job, ctx, conf.client, mappings, n)

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
@@ -47,7 +47,7 @@ object DistCopyJob {
         job.setJobName(ctx.id.value)
         job.setInputFormatClass(classOf[DistCopyInputFormat])
         job.getConfiguration.setBoolean("mapreduce.map.speculative", false)
-        job.getConfiguration.setInt("mapreduce.map.maxattempts", 1)
+        job.getConfiguration.setInt("mapreduce.map.maxattempts", if(conf.parameters.crossValidate) 1 else 3)
         job.setNumReduceTasks(0)
         job.getConfiguration.setLong(PartSize, conf.partSize.toBytes.value)
         job.getConfiguration.setInt(RetryCount, conf.retryCount)

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
@@ -132,7 +132,7 @@ class DistCopyMapper extends Mapper[NullWritable, Mapping, NullWritable, NullWri
       println(Result.asString(e))
       retryCounter.increment(1)
       context.progress()
-      Thread.sleep(200 * (math.pow(2, retryCount - n)))
+      Thread.sleep(200 * (math.pow(2, retryCount - n).toInt))
       ()
     })
 

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
@@ -101,7 +101,7 @@ class DistCopyMapper extends Mapper[NullWritable, Mapping, NullWritable, NullWri
 
     // default to sydney for historical reasons.
     val endpoint =
-      context.getConfiguration.getString(S3Endpoint, "s3-ap-southeast-2.amazonaws.com")
+      context.getConfiguration.get(S3Endpoint, "s3-ap-southeast-2.amazonaws.com")
     client =
       Clients.configured(new AmazonS3Client(), endpoint)
     crossValidate =

--- a/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
+++ b/notion-distcopy/src/main/scala/com/ambiata/notion/distcopy/DistCopyJob.scala
@@ -50,6 +50,7 @@ object DistCopyJob {
         job.getConfiguration.setInt("mapreduce.map.maxattempts", 1)
         job.setNumReduceTasks(0)
         job.getConfiguration.setLong(PartSize, conf.partSize.toBytes.value)
+        job.getConfiguration.setInt(RetryCount, conf.retryCount)
         job.getConfiguration.setInt(ReadLimit, conf.readLimit.toBytes.value.toInt)
         job.getConfiguration.setLong(MultipartUploadThreshold, conf.multipartUploadThreshold.toBytes.value)
         job.getConfiguration.setBoolean(CrossValidate, conf.parameters.crossValidate)


### PR DESCRIPTION
This will allow view and ivory to do pre-checks that will safely allow this check to be disabled. The overall effect is that retries across mappers and speculative execution will no longer break things.